### PR TITLE
Make rustls crypto provider agnostic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Check compiles for wasm32-unknown-unknown
       run: |
         rustup target add wasm32-unknown-unknown
-        RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown --features wasm --no-default-features
+        RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check --target wasm32-unknown-unknown --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "quinn",
  "rand_core 0.6.4",
  "rcgen",
+ "ring",
  "rustls",
  "rustls-pki-types",
  "rustls-webpki",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,8 +84,8 @@ dependencies = [
  "quinn",
  "rand_core 0.6.4",
  "rcgen",
- "ring",
  "rustls",
+ "rustls-pki-types",
  "rustls-webpki",
  "sha2",
  "tdx-quote",
@@ -99,6 +99,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5932a7d9d28b0d2ea34c6b3779d35e3dd6f6345317c34e73438c4f1f29144151"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1826f2e4cfc2cd19ee53c42fbf68e2f81ec21108e0b7ecf6a71cf062137360fc"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backtrace"
@@ -138,6 +161,26 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.9.4",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -185,6 +228,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -193,6 +238,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -205,6 +259,26 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmw"
@@ -411,6 +485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +524,12 @@ dependencies = [
  "sha2",
  "subtle",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -566,6 +652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +750,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -976,6 +1074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1109,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1039,6 +1156,16 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "libm"
@@ -1403,6 +1530,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1864,8 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1790,6 +1929,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 rustls = { version = "0.23.5", default-features = false }
+rustls-webpki = { version = "0.103.8", default-features = false }
 x509-parser = "0.18.0"
 asn1-rs = "0.7.1"
 sha2 = "0.10.9"
@@ -15,16 +16,17 @@ quinn = { version = "0.11.9", optional = true }
 tdx-quote = { version = "0.0.4" }
 configfs-tsm = { version = "0.0.2" }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
-rustls-webpki = "0.103.8"
 cmw = { git = "https://github.com/veraison/rust-cmw.git" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = { version = "0.23.5", default-features = true }
+rustls-webpki = { version = "0.103.8", default-features = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rustls = { version = "0.23.5", default-features = false, features = ["ring"] }
 ring = { version = "0.17.14", features = ["wasm32_unknown_unknown_js"] }
 rustls-pki-types = { version = "1.12.0", features = ["web"] }
+rustls-webpki = { version = "0.103.8", default-features = false, features = ["ring"] }
 getrandom = { version = "0.2.16", features = ["js"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "attestation-exported-authenticators"
+description = "An implementation of the draft IETF standard Remote Attestation with Exported Authenticators"
 version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,12 @@ edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
-rustls = "0.23.5"
+rustls = { version = "0.23.5", default-features = false }
 x509-parser = "0.18.0"
 asn1-rs = "0.7.1"
 sha2 = "0.10.9"
 hmac = "0.12.1"
 thiserror = "2.0.16"
-getrandom = "0.2.16"
 quinn = { version = "0.11.9", optional = true }
 tdx-quote = { version = "0.0.4" }
 configfs-tsm = { version = "0.0.2" }
@@ -19,8 +18,14 @@ rand_core = { version = "0.6.4", features = ["getrandom"] }
 rustls-webpki = "0.103.8"
 cmw = { git = "https://github.com/veraison/rust-cmw.git" }
 
-[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rustls = { version = "0.23.5", default-features = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+rustls = { version = "0.23.5", default-features = false, features = ["ring"] }
+ring = { version = "0.17.14", features = ["wasm32_unknown_unknown_js"] }
 rustls-pki-types = { version = "1.12.0", features = ["web"] }
+getrandom = { version = "0.2.16", features = ["js"] }
 
 [dev-dependencies]
 quinn = "0.11.9"
@@ -32,5 +37,4 @@ hex = "0.4.3"
 [features]
 default = ["quic"]
 mock = ["tdx-quote/mock"]
-wasm = ["getrandom/js"]
 quic = ["quinn"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,20 +5,22 @@ edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
-rustls = { version = "0.23.5", default-features = false, features=["ring"] }
+rustls = "0.23.5"
 x509-parser = "0.18.0"
 asn1-rs = "0.7.1"
 sha2 = "0.10.9"
 hmac = "0.12.1"
 thiserror = "2.0.16"
 getrandom = "0.2.16"
-ring = "0.17.14"
 quinn = { version = "0.11.9", optional = true }
 tdx-quote = { version = "0.0.4" }
 configfs-tsm = { version = "0.0.2" }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
-rustls-webpki = { version = "0.103.8", default-features = false, features = ["ring"] }
+rustls-webpki = "0.103.8"
 cmw = { git = "https://github.com/veraison/rust-cmw.git" }
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+rustls-pki-types = { version = "1.12.0", features = ["web"] }
 
 [dev-dependencies]
 quinn = "0.11.9"
@@ -30,5 +32,5 @@ hex = "0.4.3"
 [features]
 default = ["quic"]
 mock = ["tdx-quote/mock"]
-wasm = ["getrandom/js", "ring/wasm32_unknown_unknown_js"]
+wasm = ["getrandom/js"]
 quic = ["quinn"]

--- a/README.md
+++ b/README.md
@@ -18,4 +18,6 @@ By default, this test will use mock quotes so that the test will run on non-TDX 
 cargo test --no-default-features
 ```
 
+This crate can compile to `wasm32-unknown-unknown` if default features are disabled.
+
 This work is supported in part by the [Cypherpunk fellowship](https://cypherpunk.camp/#fellowship) program.

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,7 @@
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     pkg-config
+    cmake
   ];
 
   buildInputs = with pkgs;[

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,6 @@
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     pkg-config
-    cmake
   ];
 
   buildInputs = with pkgs;[

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1,13 +1,16 @@
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, PrivateKeyDer},
+};
 use thiserror::Error;
 
 use crate::{
-    DecodeError, EncodeError,
     certificate_request::CertificateRequest,
     tls_handshake_messages::{
         CMWAttestation, Certificate, CertificateEntry, CertificateVerify, Extension, ExtensionType,
         Finished, VerificationError,
     },
+    DecodeError, EncodeError,
 };
 
 /// An Authenticator as per RFC9261 Exported Authenticators
@@ -20,6 +23,7 @@ pub struct Authenticator {
 
 impl Authenticator {
     pub fn new(
+        provider: &CryptoProvider,
         certificate_chain: Vec<CertificateDer>,
         private_key: PrivateKeyDer,
         extensions: Vec<Extension>,
@@ -47,6 +51,7 @@ impl Authenticator {
         };
 
         let certificate_verify = CertificateVerify::new(
+            provider,
             &certificate,
             private_key,
             certificate_request,
@@ -71,6 +76,7 @@ impl Authenticator {
     /// Create a new authenticator with a cmw_attestation extension.
     /// Takes an encoded CMW message.
     pub fn new_with_cmw_attestation(
+        provider: &CryptoProvider,
         certificate_chain: Vec<CertificateDer>,
         private_key: PrivateKeyDer,
         cmw_attestation: CMWAttestation,
@@ -79,6 +85,7 @@ impl Authenticator {
         finished_key_exporter: [u8; 32],
     ) -> Result<Self, EncodeError> {
         Self::new(
+            provider,
             certificate_chain,
             private_key,
             vec![Extension::new_attestation_cmw(
@@ -121,6 +128,7 @@ impl Authenticator {
 
     pub fn verify(
         &self,
+        provider: &CryptoProvider,
         certificate_request: &CertificateRequest,
         handshake_context_exporter: &[u8; 64],
         finished_key_exporter: &[u8; 32],
@@ -138,6 +146,7 @@ impl Authenticator {
         }
 
         self.certificate_verify.verify(
+            provider,
             &self.certificate,
             certificate_request,
             handshake_context_exporter,
@@ -178,8 +187,11 @@ mod tests {
     use rand_core::{OsRng, RngCore};
     use rcgen::CertificateParams;
     use rustls::pki_types::PrivatePkcs8KeyDer;
+    use std::sync::Once;
 
     use super::*;
+
+    static RUSTLS_INIT: Once = Once::new();
 
     fn create_cert_der(keypair: &rcgen::KeyPair) -> Vec<u8> {
         let params = CertificateParams::new(["localhost".to_string()]).unwrap();
@@ -197,10 +209,17 @@ mod tests {
         }
     }
 
+    fn ensure_rustls_provider_installed() {
+        RUSTLS_INIT.call_once(|| {
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .unwrap();
+        });
+    }
+
     #[test]
     fn encode_decode_authenticator() {
-        let ring_provider = rustls::crypto::ring::default_provider();
-        rustls::crypto::CryptoProvider::install_default(ring_provider).unwrap();
+        ensure_rustls_provider_installed();
 
         let keypair = rcgen::KeyPair::generate().unwrap();
         let cert_der = create_cert_der(&keypair);
@@ -212,7 +231,10 @@ mod tests {
         let handshake_context_exporter = [0; 64];
         let finished_key_exporter = [0; 32];
 
+        let provider = CryptoProvider::get_default().unwrap();
+
         let authenticator = Authenticator::new(
+            &provider,
             vec![cert_der.into()],
             private_key_der,
             Vec::new(), // extensions
@@ -228,6 +250,7 @@ mod tests {
 
         authenticator
             .verify(
+                &provider,
                 &certificate_request,
                 &handshake_context_exporter,
                 &finished_key_exporter,


### PR DESCRIPTION
Currently we only support `ring` as a crypto provider, but rustls defaults to `aws_lc_sys` and it would be nice to be crypto provider agnostic.

Closes https://github.com/tls-attestation/attestation-exported-authenticators/issues/31