### PR TITLE
Add empty cmw_attestation extension to CertificateRequest message

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -202,11 +202,7 @@ mod tests {
     fn create_certificate_request() -> CertificateRequest {
         let mut context = [0u8; 32];
         OsRng.fill_bytes(&mut context);
-
-        CertificateRequest {
-            certificate_request_context: context.to_vec(),
-            extensions: b"cmw_attestation".to_vec(), // TODO
-        }
+        CertificateRequest::new_with_cmw_extension(context.to_vec())
     }
 
     fn ensure_rustls_provider_installed() {

--- a/src/certificate_request.rs
+++ b/src/certificate_request.rs
@@ -1,4 +1,4 @@
-use crate::DecodeError;
+use crate::{tls_handshake_messages::Extension, DecodeError, EncodeError};
 use std::io::Read;
 
 /// A CertificateRequest message as per RFC9261 Exported Authenticators
@@ -7,18 +7,37 @@ pub struct CertificateRequest {
     /// Context used to link the response to this request
     pub certificate_request_context: Vec<u8>,
     /// The serialized extensions
-    pub extensions: Vec<u8>,
+    pub extensions: Vec<Extension>,
 }
 
 impl CertificateRequest {
+    pub fn new_with_cmw_extension(certificate_request_context: Vec<u8>) -> Self {
+        Self {
+            certificate_request_context,
+            extensions: vec![Extension::new_attestation_cmw(Vec::new())],
+        }
+    }
+
     /// Serialize to bytes
-    pub fn encode(&self) -> Vec<u8> {
+    pub fn encode(&self) -> Result<Vec<u8>, EncodeError> {
         // Handshake type: A 1 byte value for CertificateRequest (0x0D).
         let mut encoded_message = vec![0x0D];
 
+        // Encode the extensions
+        let mut encoded_extensions = Vec::new();
+
+        for extension in self.extensions.iter() {
+            encoded_extensions.extend_from_slice(&extension.encode()?);
+        }
+
+        if encoded_extensions.len() > 0xFFFF {
+            return Err(EncodeError::ExtensionTooLong);
+        }
+
         // Handshake message length: A 3-byte value for the total length of the payload
         // + extensions (2 byte length + content)
-        let payload_length = 1 + self.certificate_request_context.len() + 2 + self.extensions.len();
+        let payload_length =
+            1 + self.certificate_request_context.len() + 2 + encoded_extensions.len();
 
         // Ensure the payload length fits within 3 bytes.
         let length_bytes = (payload_length as u32).to_be_bytes();
@@ -29,13 +48,12 @@ impl CertificateRequest {
         encoded_message.push(self.certificate_request_context.len() as u8);
         encoded_message.extend_from_slice(&self.certificate_request_context);
 
-        // Encode the extensions
-        // The length is a 2 byte value
-        let extension_length_bytes = (self.extensions.len() as u16).to_be_bytes();
-        encoded_message.extend_from_slice(&extension_length_bytes);
-        encoded_message.extend_from_slice(&self.extensions);
+        let u16_length = encoded_extensions.len() as u16;
 
-        encoded_message
+        encoded_message.extend_from_slice(&u16_length.to_be_bytes());
+        encoded_message.extend_from_slice(&encoded_extensions);
+
+        Ok(encoded_message)
     }
 
     /// Deserialize from bytes
@@ -91,7 +109,14 @@ impl CertificateRequest {
             ));
         }
         let extensions_start = cursor.position() as usize;
-        let extensions = data[extensions_start..extensions_start + extensions_length].to_vec();
+        let mut encoded_extensions = &data[extensions_start..extensions_start + extensions_length];
+
+        let mut extensions = Vec::new();
+        while !encoded_extensions.is_empty() {
+            let (extension, remaining) = Extension::decode(encoded_extensions)?;
+            extensions.push(extension);
+            encoded_extensions = remaining;
+        }
 
         Ok(CertificateRequest {
             certificate_request_context,
@@ -106,13 +131,10 @@ mod tests {
 
     #[test]
     fn encode_decode_certificate_request() {
-        let cert_request = CertificateRequest {
-            certificate_request_context: b"foo".to_vec(),
-            extensions: b"bar".to_vec(),
-        };
+        let cert_request = CertificateRequest::new_with_cmw_extension(b"foo".to_vec());
 
-        let encoded = cert_request.encode();
-        assert_eq!(encoded.len(), 1 + 3 + 1 + 3 + 2 + 3);
+        let encoded = cert_request.encode().unwrap();
+        assert_eq!(encoded.len(), 1 + 3 + 1 + 3 + 2 + 4);
 
         let decoded = CertificateRequest::decode(&encoded).unwrap();
         assert_eq!(cert_request, decoded);

--- a/src/quic/mod.rs
+++ b/src/quic/mod.rs
@@ -159,11 +159,8 @@ impl AttestedQuic {
         let mut context = [0u8; 32];
         OsRng.fill_bytes(&mut context);
 
-        let cert_request = CertificateRequest {
-            certificate_request_context: context.to_vec(),
-            extensions: b"cmw_attestation".to_vec(), // TODO #14
-        };
-        send_stream.write_all(&cert_request.encode()).await?;
+        let cert_request = CertificateRequest::new_with_cmw_extension(context.to_vec());
+        send_stream.write_all(&cert_request.encode()?).await?;
         send_stream.finish()?;
 
         // Prepare keying material which we will use for checking the quote input data

--- a/src/tls_handshake_messages.rs
+++ b/src/tls_handshake_messages.rs
@@ -282,7 +282,7 @@ impl CertificateVerify {
             // Hash(Handshake Context || authenticator request || Certificate)
             let mut hasher = Sha256::new();
             hasher.update(handshake_context_exporter);
-            hasher.update(certificate_request.encode());
+            hasher.update(certificate_request.encode()?);
             hasher.update(certificate.encode()?);
 
             hasher.finalize()
@@ -311,7 +311,7 @@ impl Finished {
         let mut mac = Hmac::<Sha256>::new_from_slice(finished_key_exporter)?;
 
         mac.update(handshake_context_exporter);
-        mac.update(&certificate_request.encode());
+        mac.update(&certificate_request.encode()?);
         mac.update(&certificate.encode()?);
         mac.update(&certificate_verify.encode()?);
 


### PR DESCRIPTION
As per the spec, when requesting an authenticator which should have a `cmw_attestation` extension, the `CertificateRequest` or `ClientCertificateRequest` should itself contain an empty `cmw_attestation` extension.

Closes https://github.com/tls-attestation/attestation-exported-authenticators/issues/14